### PR TITLE
chore: update bottom text to npx codex-wrapped

### DIFF
--- a/src/image/template.tsx
+++ b/src/image/template.tsx
@@ -625,7 +625,7 @@ function Footer() {
           letterSpacing: typography.letterSpacing.normal,
         }}
       >
-        openai.com/codex
+        npx codex-wrapped
       </span>
     </div>
   );


### PR DESCRIPTION
## Summary
- Updates the bottom text on generated images from `openai.com/codex` to `npx codex-wrapped`
- This better promotes how users can try the tool themselves when sharing their wrapped images

## Test plan
- [ ] Generate a wrapped image and verify the bottom text shows "npx codex-wrapped"