### PR TITLE
Default to all-time Codex usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@ dist
 .DS_Store
 .vscode
 .env
+.npm-cache
 
 *.tsbuildinfo

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ codex-wrapped
 
 | Option          | Description                          |
 | --------------- | ------------------------------------ |
-| `--year, -y`    | Generate wrapped for a specific year |
+| `--year, -y`    | Generate wrapped for a specific year (default: all-time) |
 | `--help, -h`    | Show help message                    |
 | `--version, -v` | Show version number                  |
 

--- a/src/image/template.tsx
+++ b/src/image/template.tsx
@@ -49,7 +49,7 @@ export function WrappedTemplate({ stats }: { stats: CodexStats }) {
           borderRadius: layout.radius.full,
         }}
       />
-      <Header year={stats.year} />
+      <Header label={stats.periodLabel} />
 
       <div style={{ marginTop: spacing[8], display: "flex", flexDirection: "row", gap: spacing[16], alignItems: "flex-start" }}>
         <HeroStatItem
@@ -88,8 +88,16 @@ export function WrappedTemplate({ stats }: { stats: CodexStats }) {
         </div>
       </div>
 
-      <Section title="Activity" marginTop={spacing[8]}>
-        <ActivityHeatmap dailyActivity={stats.dailyActivity} year={stats.year} maxStreakDays={stats.maxStreakDays} />
+      <Section title={stats.activityLabel} marginTop={spacing[8]}>
+        {"year" in stats.activityHeatmap ? (
+          <ActivityHeatmap dailyActivity={stats.dailyActivity} year={stats.activityHeatmap.year} maxStreakDays={stats.maxStreakDays} />
+        ) : (
+          <ActivityHeatmap
+            dailyActivity={stats.dailyActivity}
+            range={{ start: stats.activityHeatmap.start, end: stats.activityHeatmap.end }}
+            maxStreakDays={stats.maxStreakDays}
+          />
+        )}
       </Section>
 
       <div
@@ -115,7 +123,7 @@ export function WrappedTemplate({ stats }: { stats: CodexStats }) {
   );
 }
 
-function Header({ year }: { year: number }) {
+function Header({ label }: { label: string }) {
   return (
     <div
       style={{
@@ -181,7 +189,7 @@ function Header({ year }: { year: number }) {
               lineHeight: typography.lineHeight.none,
             }}
           >
-            {year}
+            {label}
           </span>
         </div>
       </div>

--- a/src/types.ts
+++ b/src/types.ts
@@ -71,7 +71,15 @@ export interface ProviderStats {
 }
 
 export interface CodexStats {
-  year: number;
+  /** Display label for the wrapped period (e.g. "2025", "All Time"). */
+  periodLabel: string;
+  /** Present when generating a single-year wrapped. */
+  year?: number;
+
+  /** Activity heatmap configuration. */
+  activityHeatmap: { kind: "year"; year: number } | { kind: "range"; start: Date; end: Date };
+  /** Title label for the activity section. */
+  activityLabel: string;
 
   // Time-based
   firstSessionDate: Date;

--- a/src/utils/dates.ts
+++ b/src/utils/dates.ts
@@ -57,6 +57,41 @@ export function generateWeeksForYear(year: number): string[][] {
   return weeks;
 }
 
+export function generateWeeksForRange(startDate: Date, endDate: Date): string[][] {
+  const start = new Date(startDate.getFullYear(), startDate.getMonth(), startDate.getDate());
+  const end = new Date(endDate.getFullYear(), endDate.getMonth(), endDate.getDate());
+
+  const weeks: string[][] = [];
+
+  // Adjust to start from the first Sunday (or the day itself if it's Sunday)
+  const startDay = start.getDay();
+  const adjustedStart = new Date(start);
+  if (startDay !== 0) {
+    adjustedStart.setDate(start.getDate() - startDay);
+  }
+
+  let currentDate = new Date(adjustedStart);
+  let currentWeek: string[] = [];
+
+  while (currentDate <= end || currentWeek.length > 0) {
+    const dayOfWeek = currentDate.getDay();
+    const withinRange = currentDate >= start && currentDate <= end;
+    currentWeek.push(withinRange ? formatDateKey(currentDate) : "");
+
+    if (dayOfWeek === 6) {
+      weeks.push(currentWeek);
+      currentWeek = [];
+    }
+
+    currentDate.setDate(currentDate.getDate() + 1);
+
+    // Safety: stop if we've gone too far past the end
+    if (currentDate.getTime() > end.getTime() + 32 * 24 * 60 * 60 * 1000) break;
+  }
+
+  return weeks;
+}
+
 export function formatDateKey(date: Date): string {
   const year = date.getFullYear();
   const month = String(date.getMonth() + 1).padStart(2, "0");


### PR DESCRIPTION
This PR changes Codex Wrapped to aggregate stats across your entire Codex history by default, instead of requiring a per-year run.
  - Default run (codex-wrapped) now scans all ~/.codex/sessions/<year>/... directories and totals sessions/messages/tokens/projects across all time.
  - --year/-y continues to generate a year-specific wrapped (and only then applies the “Wrapped available” date gating).
  - The header/tweet text now uses an “All Time” period label when no year is provided.
  - Activity heatmap shows the last 12 months in all-time mode; year mode remains unchanged.
